### PR TITLE
exporting fields of private key and fixing tests

### DIFF
--- a/paillier.go
+++ b/paillier.go
@@ -36,16 +36,16 @@ func GenerateKey(random io.Reader, bits int) (*PrivateKey, error) {
 			NSquared: new(big.Int).Mul(n, n),
 			G:        new(big.Int).Add(n, one), // g = n + 1
 		},
-		p:         p,
-		pp:        pp,
-		pminusone: new(big.Int).Sub(p, one),
-		q:         q,
-		qq:        qq,
-		qminusone: new(big.Int).Sub(q, one),
-		pinvq:     new(big.Int).ModInverse(p, q),
-		hp:        h(p, pp, n),
-		hq:        h(q, qq, n),
-		n:         n,
+		P:         p,
+		PP:        pp,
+		Pminusone: new(big.Int).Sub(p, one),
+		Q:         q,
+		QQ:        qq,
+		Qminusone: new(big.Int).Sub(q, one),
+		Pinvq:     new(big.Int).ModInverse(p, q),
+		HP:        h(p, pp, n),
+		HQ:        h(q, qq, n),
+		N:         n,
 	}, nil
 
 }
@@ -53,16 +53,16 @@ func GenerateKey(random io.Reader, bits int) (*PrivateKey, error) {
 // PrivateKey represents a Paillier key.
 type PrivateKey struct {
 	PublicKey
-	p         *big.Int
-	pp        *big.Int
-	pminusone *big.Int
-	q         *big.Int
-	qq        *big.Int
-	qminusone *big.Int
-	pinvq     *big.Int
-	hp        *big.Int
-	hq        *big.Int
-	n         *big.Int
+	P         *big.Int
+	PP        *big.Int
+	Pminusone *big.Int
+	Q         *big.Int
+	QQ        *big.Int
+	Qminusone *big.Int
+	Pinvq     *big.Int
+	HP        *big.Int
+	HQ        *big.Int
+	N         *big.Int
 }
 
 // PublicKey represents the public part of a Paillier key.
@@ -116,23 +116,23 @@ func Decrypt(privKey *PrivateKey, cipherText []byte) ([]byte, error) {
 		return nil, ErrMessageTooLong
 	}
 
-	cp := new(big.Int).Exp(c, privKey.pminusone, privKey.pp)
-	lp := l(cp, privKey.p)
-	mp := new(big.Int).Mod(new(big.Int).Mul(lp, privKey.hp), privKey.p)
-	cq := new(big.Int).Exp(c, privKey.qminusone, privKey.qq)
-	lq := l(cq, privKey.q)
+	cp := new(big.Int).Exp(c, privKey.Pminusone, privKey.PP)
+	lp := l(cp, privKey.P)
+	mp := new(big.Int).Mod(new(big.Int).Mul(lp, privKey.HP), privKey.P)
+	cq := new(big.Int).Exp(c, privKey.Qminusone, privKey.QQ)
+	lq := l(cq, privKey.Q)
 
-	mqq := new(big.Int).Mul(lq, privKey.hq)
-	mq := new(big.Int).Mod(mqq, privKey.q)
+	mqq := new(big.Int).Mul(lq, privKey.HQ)
+	mq := new(big.Int).Mod(mqq, privKey.Q)
 	m := crt(mp, mq, privKey)
 
 	return m.Bytes(), nil
 }
 
 func crt(mp *big.Int, mq *big.Int, privKey *PrivateKey) *big.Int {
-	u := new(big.Int).Mod(new(big.Int).Mul(new(big.Int).Sub(mq, mp), privKey.pinvq), privKey.q)
-	m := new(big.Int).Add(mp, new(big.Int).Mul(u, privKey.p))
-	return new(big.Int).Mod(m, privKey.n)
+	u := new(big.Int).Mod(new(big.Int).Mul(new(big.Int).Sub(mq, mp), privKey.Pinvq), privKey.Q)
+	m := new(big.Int).Add(mp, new(big.Int).Mul(u, privKey.P))
+	return new(big.Int).Mod(m, privKey.N)
 }
 
 // AddCipher homomorphically adds together two cipher texts.

--- a/paillier_test.go
+++ b/paillier_test.go
@@ -6,75 +6,6 @@ import (
 	"testing"
 )
 
-/*
-
-	fmt.Println("N :=new(big.Int)")
-	fmt.Print("N.SetString(\"")
-	fmt.Print(key.PublicKey.N)
-	fmt.Println("\", 10)")
-
-	fmt.Println("NSquared :=new(big.Int)")
-	fmt.Print("NSquared.SetString(\"")
-	fmt.Print(key.PublicKey.NSquared)
-	fmt.Println("\", 10)")
-
-	fmt.Println("G :=new(big.Int)")
-	fmt.Print("G.SetString(\"")
-	fmt.Print(key.PublicKey.G)
-	fmt.Println("\", 10)")
-
-	fmt.Println("p :=new(big.Int)")
-	fmt.Print("p.SetString(\"")
-	fmt.Print(key.p)
-	fmt.Println("\", 10)")
-
-	fmt.Println("pp :=new(big.Int)")
-	fmt.Print("pp.SetString(\"")
-	fmt.Print(key.pp)
-	fmt.Println("\", 10)")
-
-	fmt.Println("pminusone :=new(big.Int)")
-	fmt.Print("pminusone.SetString(\"")
-	fmt.Print(key.pminusone)
-	fmt.Println("\", 10)")
-
-	fmt.Println("q :=new(big.Int)")
-	fmt.Print("q.SetString(\"")
-	fmt.Print(key.q)
-	fmt.Println("\", 10)")
-
-	fmt.Println("qq :=new(big.Int)")
-	fmt.Print("qq.SetString(\"")
-	fmt.Print(key.qq)
-	fmt.Println("\", 10)")
-
-	fmt.Println("qminusone :=new(big.Int)")
-	fmt.Print("qminusone.SetString(\"")
-	fmt.Print(key.qminusone)
-	fmt.Println("\", 10)")
-
-	fmt.Println("pinvq :=new(big.Int)")
-	fmt.Print("pinvq.SetString(\"")
-	fmt.Print(key.pinvq)
-	fmt.Println("\", 10)")
-
-	fmt.Println("hp :=new(big.Int)")
-	fmt.Print("hp.SetString(\"")
-	fmt.Print(key.hp)
-	fmt.Println("\", 10)")
-
-	fmt.Println("hq :=new(big.Int)")
-	fmt.Print("hq.SetString(\"")
-	fmt.Print(key.hq)
-	fmt.Println("\", 10)")
-
-	fmt.Println("n :=new(big.Int)")
-	fmt.Print("n.SetString(\"")
-	fmt.Print(key.n)
-	fmt.Println("\", 10)")
-
-*/
-
 func params1024() (*PrivateKey, error) {
 
 	N := new(big.Int)
@@ -110,16 +41,16 @@ func params1024() (*PrivateKey, error) {
 			NSquared: NSquared,
 			G:        G,
 		},
-		p:         p,
-		pp:        pp,
-		pminusone: pminusone,
-		q:         q,
-		qq:        qq,
-		qminusone: qminusone,
-		pinvq:     pinvq,
-		hp:        hp,
-		hq:        hq,
-		n:         n,
+		P:         p,
+		PP:        pp,
+		Pminusone: pminusone,
+		Q:         q,
+		QQ:        qq,
+		Qminusone: qminusone,
+		Pinvq:     pinvq,
+		HP:        hp,
+		HQ:        hq,
+		N:         n,
 	}
 
 	return &pk, nil
@@ -159,16 +90,16 @@ func params2048() (*PrivateKey, error) {
 			NSquared: NSquared,
 			G:        G,
 		},
-		p:         p,
-		pp:        pp,
-		pminusone: pminusone,
-		q:         q,
-		qq:        qq,
-		qminusone: qminusone,
-		pinvq:     pinvq,
-		hp:        hp,
-		hq:        hq,
-		n:         n,
+		P:         p,
+		PP:        pp,
+		Pminusone: pminusone,
+		Q:         q,
+		QQ:        qq,
+		Qminusone: qminusone,
+		Pinvq:     pinvq,
+		HP:        hp,
+		HQ:        hq,
+		N:         n,
 	}
 
 	return &pk, nil
@@ -209,16 +140,16 @@ func params3072() (*PrivateKey, error) {
 			NSquared: NSquared,
 			G:        G,
 		},
-		p:         p,
-		pp:        pp,
-		pminusone: pminusone,
-		q:         q,
-		qq:        qq,
-		qminusone: qminusone,
-		pinvq:     pinvq,
-		hp:        hp,
-		hq:        hq,
-		n:         n,
+		P:         p,
+		PP:        pp,
+		Pminusone: pminusone,
+		Q:         q,
+		QQ:        qq,
+		Qminusone: qminusone,
+		Pinvq:     pinvq,
+		HP:        hp,
+		HQ:        hq,
+		N:         n,
 	}
 
 	return &pk, nil
@@ -258,16 +189,16 @@ func params4096() (*PrivateKey, error) {
 			NSquared: NSquared,
 			G:        G,
 		},
-		p:         p,
-		pp:        pp,
-		pminusone: pminusone,
-		q:         q,
-		qq:        qq,
-		qminusone: qminusone,
-		pinvq:     pinvq,
-		hp:        hp,
-		hq:        hq,
-		n:         n,
+		P:         p,
+		PP:        pp,
+		Pminusone: pminusone,
+		Q:         q,
+		QQ:        qq,
+		Qminusone: qminusone,
+		Pinvq:     pinvq,
+		HP:        hp,
+		HQ:        hq,
+		N:         n,
 	}
 
 	return &pk, nil
@@ -395,21 +326,21 @@ func TestPrintParams(t *testing.T) {
 	// Generate a 128-bit private key.
 	privKey, err := GenerateKey(rand.Reader, 4092)
 	if err != nil {
-		t.Fatalf("Unable to generate private key: ", err)
+		t.Fatalf("Unable to generate private key: %v", err)
 	}
 
 	// Encrypt the integer 15.
 	m15 := new(big.Int).SetInt64(15)
 	c15, err := Encrypt(&privKey.PublicKey, m15.Bytes())
 	if err != nil {
-		t.Fatalf("Unable to encrypt plain text: ", err)
+		t.Fatalf("Unable to encrypt plain text: %v", err)
 	}
 
 	// Encrypt the integer 20.
 	m20 := new(big.Int).SetInt64(20)
 	c20, err := Encrypt(&privKey.PublicKey, m20.Bytes())
 	if err != nil {
-		t.Fatalf("Unable to encrypt plain text: ", err)
+		t.Fatalf("Unable to encrypt plain text: %v", err)
 	}
 
 	// Now homomorphically add the encrypted integers.
@@ -418,7 +349,7 @@ func TestPrintParams(t *testing.T) {
 	// When decrypted, the result should be 15+20 = 35
 	plaintext, err := Decrypt(privKey, addedCiphers)
 	if err != nil {
-		t.Fatalf("Unable to decrypted cipher text: ", err)
+		t.Fatalf("Unable to decrypted cipher text: %v", err)
 	}
 	decryptedInt := new(big.Int).SetBytes(plaintext)
 	if decryptedInt.Cmp(new(big.Int).SetInt64(35)) != 0 {
@@ -432,20 +363,20 @@ func TestCorrectness(t *testing.T) {
 	// Generate a 128-bit private key.
 	privKey, err := GenerateKey(rand.Reader, 128)
 	if err != nil {
-		t.Fatalf("Unable to generate private key: ", err)
+		t.Fatalf("Unable to generate private key: %v", err)
 	}
 
 	// Encrypt the integer 15.
 	m := new(big.Int).SetInt64(15)
 	c, err := Encrypt(&privKey.PublicKey, m.Bytes())
 	if err != nil {
-		t.Fatalf("Unable to encrypt plain text: ", err)
+		t.Fatalf("Unable to encrypt plain text: %v", err)
 	}
 
 	// Now decrypt the cipher text. Should come back out to 15.
 	d, err := Decrypt(privKey, c)
 	if err != nil {
-		t.Fatalf("Unable to decrypt cipher text: ", err)
+		t.Fatalf("Unable to decrypt cipher text: %v", err)
 	}
 	originalInt := new(big.Int).SetBytes(d)
 	if originalInt.Cmp(m) != 0 { // originalInt != 15
@@ -458,21 +389,21 @@ func TestHomomorphicCipherTextAddition(t *testing.T) {
 	// Generate a 128-bit private key.
 	privKey, err := GenerateKey(rand.Reader, 128)
 	if err != nil {
-		t.Fatalf("Unable to generate private key: ", err)
+		t.Fatalf("Unable to generate private key: %v", err)
 	}
 
 	// Encrypt the integer 15.
 	m15 := new(big.Int).SetInt64(15)
 	c15, err := Encrypt(&privKey.PublicKey, m15.Bytes())
 	if err != nil {
-		t.Fatalf("Unable to encrypt plain text: ", err)
+		t.Fatalf("Unable to encrypt plain text: %v", err)
 	}
 
 	// Encrypt the integer 20.
 	m20 := new(big.Int).SetInt64(20)
 	c20, err := Encrypt(&privKey.PublicKey, m20.Bytes())
 	if err != nil {
-		t.Fatalf("Unable to encrypt plain text: ", err)
+		t.Fatalf("Unable to encrypt plain text: %v", err)
 	}
 
 	// Now homomorphically add the encrypted integers.
@@ -481,7 +412,7 @@ func TestHomomorphicCipherTextAddition(t *testing.T) {
 	// When decrypted, the result should be 15+20 = 35
 	plaintext, err := Decrypt(privKey, addedCiphers)
 	if err != nil {
-		t.Fatalf("Unable to decrypted cipher text: ", err)
+		t.Fatalf("Unable to decrypted cipher text: %v", err)
 	}
 	decryptedInt := new(big.Int).SetBytes(plaintext)
 	if decryptedInt.Cmp(new(big.Int).SetInt64(35)) != 0 {
@@ -494,14 +425,14 @@ func TestHomomorphicConstantAddition(t *testing.T) {
 	// Generate a 128-bit private key.
 	privKey, err := GenerateKey(rand.Reader, 128)
 	if err != nil {
-		t.Fatalf("Unable to generate private key: ", err)
+		t.Fatalf("Unable to generate private key: %v", err)
 	}
 
 	// Encrypt the integer 15.
 	m15 := new(big.Int).SetInt64(15)
 	c15, err := Encrypt(&privKey.PublicKey, m15.Bytes())
 	if err != nil {
-		t.Fatalf("Unable to encrypt plain text: ", err)
+		t.Fatalf("Unable to encrypt plain text: %v", err)
 	}
 
 	// Attempt to add the plaintext constant "10" to our encrypted integer
@@ -510,7 +441,7 @@ func TestHomomorphicConstantAddition(t *testing.T) {
 	encryptedAdd := Add(&privKey.PublicKey, c15, ten.Bytes())
 	plainText, err := Decrypt(privKey, encryptedAdd)
 	if err != nil {
-		t.Fatalf("Unable to decrypt cipher text: ", err)
+		t.Fatalf("Unable to decrypt cipher text: %v", err)
 	}
 	decryptedInt := new(big.Int).SetBytes(plainText)
 
@@ -526,14 +457,14 @@ func TestHomomorphicConstantMultiplication(t *testing.T) {
 	// Generate a 128-bit private key.
 	privKey, err := GenerateKey(rand.Reader, 128)
 	if err != nil {
-		t.Fatalf("Unable to generate private key: ", err)
+		t.Fatalf("Unable to generate private key: %v", err)
 	}
 
 	// Encrypt the integer 15.
 	m15 := new(big.Int).SetInt64(15)
 	c15, err := Encrypt(&privKey.PublicKey, m15.Bytes())
 	if err != nil {
-		t.Fatalf("Unable to encrypt plain text: ", err)
+		t.Fatalf("Unable to encrypt plain text: %v", err)
 	}
 
 	// Attempt to multiply our encrypted integer
@@ -541,7 +472,7 @@ func TestHomomorphicConstantMultiplication(t *testing.T) {
 	encryptedAdd := Mul(&privKey.PublicKey, c15, ten.Bytes())
 	plainText, err := Decrypt(privKey, encryptedAdd)
 	if err != nil {
-		t.Fatalf("Unable to decrypt cipher text: ", err)
+		t.Fatalf("Unable to decrypt cipher text: %v", err)
 	}
 	decryptedInt := new(big.Int).SetBytes(plainText)
 


### PR DESCRIPTION
I wanted to use `gob.Encode` to write the private key to a file. To do so, I had to export the fields of the private key.
Like a good boy scout I also fixed some of the error messages in the tests.